### PR TITLE
Short-circuit set_locale when context is the same.

### DIFF
--- a/class.wp-cldr.php
+++ b/class.wp-cldr.php
@@ -36,6 +36,10 @@ class WP_CLDR {
 	}
 
 	public function set_locale( $locale ) {
+		if ( $locale === $this->locale && isset( $this->localized[ $locale ] ) && ! empty( $this->localized[ $locale ] ) ) {
+			// No need to do duplicate work when setting the same locale repeatedly
+			return;
+		}
 		$this->locale = $locale;
 		$this->initialize_locale( $locale );
 	}


### PR DESCRIPTION
No need to do duplicate work when setting the same locale repeatedly

fixes #1
