### PR TITLE
fix type mismatch issue in get_localized_name()

### DIFF
--- a/class.wp-cldr.php
+++ b/class.wp-cldr.php
@@ -195,7 +195,7 @@ class WP_CLDR {
 	* @param  string $locale (optional) Which locale's strings to return.
 	*                           Defaults to the current locale (which defaults to English).
 	* @param string $bucket     The bucket for the CLDR data request
-	* @return object            Values for keys initialized for a particular locale
+	* @return array            Values for keys initialized for a particular locale
 	*/
 	public function get_localized_names( $locale = null , $bucket = 'territories' ) {
 		if ( ! $locale ) {
@@ -214,7 +214,7 @@ class WP_CLDR {
 		}
 
 		// Really not found
-		return new StdClass();
+		return null;
 	}
 
 	/**

--- a/class.wp-cldr.php
+++ b/class.wp-cldr.php
@@ -195,7 +195,7 @@ class WP_CLDR {
 	* @param  string $locale (optional) Which locale's strings to return.
 	*                           Defaults to the current locale (which defaults to English).
 	* @param string $bucket     The bucket for the CLDR data request
-	* @return array            Values for keys initialized for a particular locale
+	* @return array             Values for keys initialized for a particular locale
 	*/
 	public function get_localized_names( $locale = null , $bucket = 'territories' ) {
 		if ( ! $locale ) {


### PR DESCRIPTION
our double-extra-safe-not-found case in get_localized_name() (which I’ve never managed to trigger) was returning an empty object when the function now generally returns an array. IIRC when first written this function did return objects, but I switched it over to arrays. I _think_ we should fix this but am admittedly a bit hazy on what caching issue this last check is trying to catch.

is there a way to simplify these various checks further?