### PR TITLE
Fix Travis false positives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-   - '5.2'
+   - '5.6'
    - '7.0'
 
 notifications:


### PR DESCRIPTION
Travis is generating false positives for WordPress minimum PHP 5.2; 5.6 is enough for now