### PR TITLE
Anchor `get_territories_contained` regexes

### DIFF
--- a/class-wp-cldr.php
+++ b/class-wp-cldr.php
@@ -572,12 +572,12 @@ class WP_CLDR {
 	public function get_territories_contained( $region_code ) {
 
 		// If $region_code is a country code, return it.
-		if ( preg_match( '/[A-Z]{2}/', $region_code ) ) {
+		if ( preg_match( '/^[A-Z]{2}$/', $region_code ) ) {
 			return array( $region_code );
 		}
 
 		// If it's a region code, recursively find the contained country codes.
-		if ( preg_match( '/\d{3}/', $region_code ) ) {
+		if ( preg_match( '/^\d{3}$/', $region_code ) ) {
 			$result = array();
 			$json_file = $this->get_locale_bucket( 'supplemental', 'territoryContainment' );
 			if ( isset( $json_file['supplemental']['territoryContainment'][ $region_code ]['_contains'] ) ) {


### PR DESCRIPTION
Anchor `get_territories_contained` regexes to the start & end of inspected strings

Otherwise, we could be matching strings here that we shouldn't.

As noted [here](https://github.com/Automattic/wp-cldr/commit/0d65a5c02f84260a1c9033595dc90b02180801d1#commitcomment-16479029) -- thanks, @akirk!