### PR TITLE
update method names to remove extraneous `_by_locale`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Open up a new issue on Github at https://github.com/Automattic/wp-cldr/issues. W
 ### The default locale is English
 ```
 $cldr = new WP_CLDR();
-$territories_in_english = $cldr->get_territories_by_locale();
+$territories_in_english = $cldr->get_territories();
 ```
 
 ### You can override the default locale per-call by passing in a language slug in the second parameter

--- a/class-wp-cldr.php
+++ b/class-wp-cldr.php
@@ -22,7 +22,7 @@
  *
  * ```
  * $cldr = new WP_CLDR();
- * $territories_in_english = $cldr->get_territories_by_locale( 'en' );
+ * $territories_in_english = $cldr->get_territories();
  * ```
  *
  * You can override the default locale per-call by passing in a language slug in the second parameter:
@@ -297,7 +297,7 @@ class WP_CLDR {
 	public function flush_all_wp_caches() {
 		$this->localized = array();
 
-		$locales = $this->get_languages_by_locale( 'en' );
+		$locales = $this->get_languages();
 		$supported_buckets = array( 'territories', 'currencies', 'languages', 'weekData', 'telephoneCodeData' );
 		foreach ( array_keys( $locales ) as $locale ) {
 			foreach ( $supported_buckets as $bucket ) {
@@ -434,7 +434,7 @@ class WP_CLDR {
 	 * @param string $locale Optional. A WordPress locale code.
 	 * @return array An associative array of ISO 3166-1 alpha-2 country codes and UN M.49 region codes, along with localized names, from CLDR
 	 */
-	public function get_territories_by_locale( $locale = '' ) {
+	public function get_territories( $locale = '' ) {
 		return $this->get_locale_bucket( $locale, 'territories' );
 	}
 
@@ -446,7 +446,7 @@ class WP_CLDR {
 	 * @param string $locale Optional. A WordPress locale code.
 	 * @return array An associative array of ISO 639 codes and localized language names from CLDR
 	 */
-	public function get_languages_by_locale( $locale = '' ) {
+	public function get_languages( $locale = '' ) {
 		return $this->get_locale_bucket( $locale, 'languages' );
 	}
 

--- a/tests/wp-cldr-tests.php
+++ b/tests/wp-cldr-tests.php
@@ -73,25 +73,25 @@ class WP_CLDR_Tests extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'Canadian French', $this->cldr->get_language_name( 'fr-ca' , '' ) );
 	}
 
-	public function test_get_territories_by_locale() {
+	public function test_get_territories() {
 
-		$territories_in_english = $this->cldr->get_territories_by_locale( 'en' );
+		$territories_in_english = $this->cldr->get_territories();
 		$this->assertArrayHasKey( 'US', $territories_in_english );
 		$this->assertEquals( 'United States', $territories_in_english['US'] );
 
 		// Test some bad slugs.
-		$all_territories = $this->cldr->get_territories_by_locale( 'bad-slug' );
+		$all_territories = $this->cldr->get_territories( 'bad-slug' );
 		$this->assertEquals( 'United States', $all_territories['US'] );
 	}
 
-	public function test_get_languages_by_locale() {
+	public function test_get_languages() {
 
-		$languages_in_english = $this->cldr->get_languages_by_locale( 'en' );
+		$languages_in_english = $this->cldr->get_languages();
 		$this->assertArrayHasKey( 'en', $languages_in_english );
 		$this->assertEquals( 'German', $languages_in_english['de'] );
 
 		// Test some bad slugs.
-		$all_languages = $this->cldr->get_languages_by_locale( 'bad-slug' );
+		$all_languages = $this->cldr->get_languages( 'bad-slug' );
 		$this->assertEquals( 'English', $all_languages['en'] );
 	}
 


### PR DESCRIPTION
Removes an unnecessary `_by_locale` from a few method names. Leaves in the optional locale parameter for those methods to give users chance to override the current locale setting (as most methods in class do).

Addresses #74.