### PR TITLE
refactor out get_cldr_item()

### DIFF
--- a/class-wp-cldr.php
+++ b/class-wp-cldr.php
@@ -334,28 +334,6 @@ class WP_CLDR {
 	}
 
 	/**
-	 * Gets the localized value for a single data item in a bucket of localized CLDR data.
-	 *
-	 * @param string $key    A key of a CLDR data item.
-	 * @param string $locale A WordPress locale code.
-	 * @param string $bucket A CLDR data item.
-	 * @return string The localized CLDR data item in the selected locale.
-	 */
-	private function get_cldr_item( $key, $locale, $bucket ) {
-		if ( ! is_string( $key ) || ! strlen( $key ) ) {
-			return '';
-		}
-
-		$bucket_array = $this->get_locale_bucket( $locale, $bucket );
-
-		if ( isset( $bucket_array[ $key ] ) ) {
-			return (string) $bucket_array[ $key ];
-		}
-
-		return '';
-	}
-
-	/**
 	 * Gets a localized country or region name.
 	 *
 	 * @link http://www.iso.org/iso/country_codes ISO 3166 country codes
@@ -366,7 +344,11 @@ class WP_CLDR {
 	 * @return string The name of the territory in the provided locale.
 	 */
 	public function get_territory_name( $territory_code, $locale = '' ) {
-		return $this->get_cldr_item( $territory_code, $locale, 'territories' );
+		$territories_array = $this->get_territories_by_locale( $locale );
+		if ( isset( $territories_array[ $territory_code ] ) ) {
+			return $territories_array[ $territory_code ];
+		}
+		return '';
 	}
 
 	/**
@@ -415,14 +397,18 @@ class WP_CLDR {
 	public function get_language_name( $language_code, $locale = '' ) {
 		$cldr_matched_language_code = $this->get_cldr_locale( $language_code );
 
-		$language_name = $this->get_cldr_item( $cldr_matched_language_code, $locale, 'languages' );
-
-		// If no match for locale (language-COUNTRY), try falling back to CLDR-matched language code only.
-		if ( empty( $language_name ) ) {
-			$language_name = $this->get_cldr_item( strtok( $language_code, '-_' ), $locale, 'languages' );
+		$languages = $this->get_languages_by_locale( $locale );
+		if ( isset( $languages[ $cldr_matched_language_code ] ) ) {
+			return $languages[ $cldr_matched_language_code ];
 		}
 
-		return $language_name;
+		// If no match for a full language code (e.g. `en-NZ`), check for language code only (e.g. `en`).
+		$language_only_cldr_code = strtok( $cldr_matched_language_code, '-_' );
+		if ( isset( $languages[ $language_only_cldr_code ] ) ) {
+			return $languages[ $language_only_cldr_code ];
+		}
+
+		return '';
 	}
 
 	/**


### PR DESCRIPTION
@jblz, back in the day, when the plugin handled a single data structure like used in territory and language names, we added an intermediate method -- `get_cldr_item()` -- to look up an item in a locale bucket.

As we've expanded the data items available, there are now different data structures involved. `get_cldr_item()` feels like an extra layer, a bit of complexity that usually trips me up when I've been away from the code for a while.

This PR refactors it out.  It's pretty straightforward -- we only use `get_cldr_item()` for territory names and language names. In both cases, we already have a public function that generates an array of all values.

One thing that was in `get_cldr_item()` and is now missing -- and has always been missing from the other public methods -- is argument validation. The docblocks call for strings, but we aren't confirming anywhere that the passed arguments are in fact strings. We could add that throughout the class something like:

```
		foreach ( func_get_args() as $argument ) {
			if ( ! is_string( $argument ) ) {
				return '';
			}
		}
```

It seems like a lot of code clutter just to avoid issues for developers who don't follow the documentation so I'm leaning against it. What do you think?