### PR TITLE
Small Admin Page Tweaks

### DIFF
--- a/wp-cldr.php
+++ b/wp-cldr.php
@@ -61,13 +61,9 @@ function wp_cldr_settings() {
 	?>
 
 	<div class="wrap">
-	<h1><?php esc_html_e( 'WP CLDR settings and info', 'wp-cldr' ); ?></h1>
-	<?php esc_html_e( 'This plugin gives WordPress developers easy access to localized country, region, language, currency, and calendar info from the Unicode Common Locale Data Repository. See examples below. More at: ', 'wp-cldr' ); ?>
-	<a href="http://automattic.github.io/wp-cldr/class-WP_CLDR.html" ><?php esc_html_e( 'Detailed API documentation', 'wp-cldr' ); ?></a>,
-	<a href="https://github.com/Automattic/wp-cldr" ><?php esc_html_e( 'GitHub repo', 'wp-cldr' ); ?></a>.
-	<br>
-
-	<br>
+	<h1><?php esc_html_e( 'WP CLDR examples and info', 'wp-cldr' ); ?></h1>
+	<?php esc_html_e( 'This plugin gives WordPress developers easy access to localized country, region, language, currency, and calendar info from the Unicode Common Locale Data Repository.', 'wp-cldr' ); ?>
+	<h2><?php esc_html_e( 'Examples', 'wp-cldr' ); ?></h2>
 	<form method="get" name='locale'>
 	<table width="75%">
 	<tr>
@@ -244,11 +240,21 @@ function wp_cldr_settings() {
 		// Use default formatting rules.
 		echo esc_html( number_format( $population ) );
 	}
-
-	echo '<br><br><br><br>';
+	?>
+	<h2><?php esc_html_e( 'Active Version Information', 'wp-cldr' ); ?></h2>
+	<?php
 	$plugin_path = WP_PLUGIN_DIR . '/wp-cldr/wp-cldr.php';
 	$plugin_info = get_plugin_data( $plugin_path );
-	echo 'Plugin version ' . esc_html( $plugin_info['Version'] ) . '<br>';
-	echo 'CLDR version ' . esc_html( WP_CLDR::CLDR_VERSION );
+	?>
+	<ul>
+		<li><?php echo esc_html( sprintf( __( 'wp-cldr plugin version: %s', 'wp-cldr' ), $plugin_info['Version'] ) ); ?></li>
+		<li><?php echo esc_html( sprintf( __( 'CLDR version: %s', 'wp-cldr' ), WP_CLDR::CLDR_VERSION ) ); ?></li>
+	</ul>
+	<h2><?php esc_html_e( 'External Links', 'wp-cldr' );?> <span class="dashicons dashicons-external"></span></h2>
+	<ul>
+		<li><a href="http://cldr.unicode.org/" target="_blank">Unicode Common Locale Data Repository</a></li>
+		<li><a href="https://github.com/Automattic/wp-cldr" target="_blank"><?php esc_html_e( 'wp-cldr plugin GitHub repo', 'wp-cldr' ); ?></a></li>
+		<li><a href="http://automattic.github.io/wp-cldr/class-WP_CLDR.html" target="_blank"><?php esc_html_e( 'wp-cldr plugin detailed API documentation', 'wp-cldr' ); ?></a></li>
+	</ul>
+	<?php
 }
-?>


### PR DESCRIPTION
in preparation for initial wporg repo release
* Move the "More Information" part of the description string to an h2 & a dashicon-external to indicate these are external links
* Convert the items in the "More Information" list to a proper unordered list
* Add a link to the CLDR project's page
* String & ordering tweaks
* Call out examples in an h2

Before:
<img width="1242" alt="screen shot 2016-03-17 at 3 38 57 pm" src="https://cloud.githubusercontent.com/assets/1587282/13858965/60bdb33a-ec57-11e5-8c2e-3c0ae2b52f55.png">

After:
<img width="1185" alt="screen shot 2016-03-17 at 3 50 01 pm" src="https://cloud.githubusercontent.com/assets/1587282/13859068/e8ddbc9c-ec57-11e5-9a67-b90cc0c32d3b.png">
