### PR TITLE
Parse the population as int before formatting it.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,10 @@ Open up a new issue on GitHub at https://github.com/Automattic/wp-cldr/issues. W
 4. Examples of data available for the locale `hi_IN`, Hindi
 
 == Changelog ==
+= 1.2.1 = (July, 2024) =
+
+* Fix a type error when displaying the population in the admin panel
+
 = 1.2 = (Jun, 2024) =
 
 * Update for CLDR 45.0.0

--- a/tests/WPCLDRTests.php
+++ b/tests/WPCLDRTests.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  * Performs unit tests against the wp-cldr plugin.
  */
 final class WPCLDRTests extends TestCase {
-
+	protected $cldr;
 	protected function setup() : void {
 		// The second parameter, false, tells the class to not use caching which means we can avoid loading WordPress for these tests.
 		$this->cldr = new WP_CLDR( 'en', false );

--- a/wp-cldr.php
+++ b/wp-cldr.php
@@ -5,7 +5,7 @@
  * Plugin URI:  https://github.com/Automattic/wp-cldr
  * Author:      Automattic
  * Author URI:  https://automattic.com
- * Version:     1.2
+ * Version:     1.2.1
  * Text Domain: wp-cldr
  * Domain Path: /languages
  * License:     GPLv2 or later
@@ -235,7 +235,7 @@ function wp_cldr_settings() {
 	esc_html_e( 'Population', 'wp-cldr' );
 	echo '</i> — ';
 	$territory_info = $cldr->get_territory_info( $country );
-	$population = $territory_info['_population'];
+	$population = (int) $territory_info['_population'];
 	if ( class_exists( 'NumberFormatter' ) ) {
 		// Use locale formatting rules.
 		$fmt = new NumberFormatter( $locale, NumberFormatter::DECIMAL );


### PR DESCRIPTION
As the plugin file uses `declare( strict_types=1 );`, the population should be parsed as int before formatting it, to avoid type errors as both `number_format` and `NumberFormatter` accept `int|float`. 