### PR TITLE
Update wp-cldr to version 1.3

### DIFF
--- a/class-wp-cldr.php
+++ b/class-wp-cldr.php
@@ -89,7 +89,7 @@ class WP_CLDR {
 	/**
 	 * The CLDR version, which the class uses to determine path to JSON files.
 	 */
-	const CLDR_VERSION = '45.0.0';
+	const CLDR_VERSION = '46.0.0';
 
 	/**
 	 * Constructs a new instance of the class, including setting defaults for locale and caching.

--- a/get-cldr-files.sh
+++ b/get-cldr-files.sh
@@ -7,7 +7,7 @@ if [ "wp-cldr" != "${PWD##*/}" ]; then
 fi
 
 # set the CLDR version
-CLDRVERSION="45.0.0"
+CLDRVERSION="46.0.0"
 
 DATA_DIR="$PWD"/data/$CLDRVERSION
 

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,10 @@ Open up a new issue on GitHub at https://github.com/Automattic/wp-cldr/issues. W
 4. Examples of data available for the locale `hi_IN`, Hindi
 
 == Changelog ==
+= 1.3.0 = (Nov, 2024) =
+
+* Update for CLDR 46.0.0
+
 = 1.2.1 = (July, 2024) =
 
 * Fix a type error when displaying the population in the admin panel

--- a/tests/WPCLDRTests.php
+++ b/tests/WPCLDRTests.php
@@ -293,7 +293,7 @@ final class WPCLDRTests extends TestCase {
 
 		// The number of time zone exemplar cities is dynamic this range should cover it.
 		$this->assertGreaterThan( 400, count( $this->cldr->get_time_zone_cities() ) );
-		$this->assertLessThan( 475, count( $this->cldr->get_time_zone_cities() ) );
+		$this->assertLessThan( 500, count( $this->cldr->get_time_zone_cities() ) );
 
 		// Test some bad slugs.
 		$time_zone_cities = $this->cldr->get_time_zone_cities( 'bad-slug' );


### PR DESCRIPTION
This diff updates the CLDR version to 46.0.0.


## Testing instructions
1.  Run ./get-cldr-files.sh
1. Confirm that a new 46.0.0 folder was created in the data folder
1. Run php prune-cldr-files.php to delete unneeded files.
1. Confirm that the size of the 46.0.0 folder is similar to the already existing 41.0.0
1. Run unit tests
